### PR TITLE
Move category check upwards

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -84,6 +84,18 @@ func BenchmarkLogFields(b *testing.B) {
 	})
 }
 
+func BenchmarkLogCategory(b *testing.B) {
+	logger := New(ioutil.Discard)
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logger.Info().
+				Category(2).
+				Msg(fakeMessage)
+		}
+	})
+}
+
 type obj struct {
 	Pub  string
 	Tag  string `json:"tag"`
@@ -159,6 +171,7 @@ func BenchmarkLogFieldType(b *testing.B) {
 		obj{"a", "a", 0},
 	}
 	errs := []error{errors.New("a"), errors.New("b"), errors.New("c"), errors.New("d"), errors.New("e")}
+	var category Category = 1
 	types := map[string]func(e *Event) *Event{
 		"Bool": func(e *Event) *Event {
 			return e.Bool("k", bools[0])
@@ -216,6 +229,9 @@ func BenchmarkLogFieldType(b *testing.B) {
 		},
 		"Object": func(e *Event) *Event {
 			return e.Object("k", objects[0])
+		},
+		"Category": func(e *Event) *Event {
+			return e.Category(category)
 		},
 	}
 	logger := New(ioutil.Discard)

--- a/category.go
+++ b/category.go
@@ -1,0 +1,67 @@
+package zerolog
+
+import (
+	"math"
+	"sync"
+)
+
+// Category represents log event categories.
+type Category uint8
+
+type categoryDef struct {
+	name string
+	lvl  Level
+}
+
+const maxcategories = math.MaxUint8
+
+var (
+	categories [maxcategories]categoryDef
+	catmx      sync.RWMutex
+)
+
+// SetCategory sets the name and the log level for category cat.
+//
+// This function is not safe for use by multiple goroutines.
+func SetCategory(cat Category, name string, lvl Level) {
+	categories[cat].lvl = lvl
+	categories[cat].name = name
+}
+
+// SetCategoryLevel sets the level for category cat, that is, the minimum
+// accepted log level for events of that category to be actually logged. Events
+// can be assigned a category by calling Event.Cat().
+//
+// This function is safe for use by multiple goroutines.
+func SetCategoryLevel(cat Category, lvl Level) {
+	catmx.Lock()
+	SetCategoryLevelUnsafe(cat, lvl)
+	catmx.Unlock()
+}
+
+// LockCategoryLevels locks the underlying store of category log levels.
+//
+// When you're done calling SetCategoryLevelUnsafe() you must call UnlockCategoryLevelUnsafe.
+func LockCategoryLevels() { catmx.Lock() }
+
+// UnlockCategoryLevels unlocks the underlying store of category log levels.
+func UnlockCategoryLevels() { catmx.Unlock() }
+
+// SetCategoryLevelUnsafe sets the level for category cat, that is, the minimum
+// accepted log level for events of that category to be actually logged. Events
+// can be assigned a category by calling Event.Cat().
+//
+// NOTICE: useful for batch updating of category log levels when other goroutines are running.
+func SetCategoryLevelUnsafe(cat Category, lvl Level) { categories[cat].lvl = lvl }
+
+// shouldCategory returns true if an event with category cat and level lvl
+// should be logged. name is set to the category name if that is the case.
+func shouldCategory(cat Category, lvl Level) (ok bool, name string) {
+	catmx.RLock()
+	if lvl >= categories[cat].lvl {
+		ok = true
+		name = categories[cat].name
+	}
+	catmx.RUnlock()
+	return
+}

--- a/console_test.go
+++ b/console_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/rs/zerolog"
+	"github.com/arl/zerolog"
 )
 
 func ExampleConsoleWriter_Write() {

--- a/diode/diode.go
+++ b/diode/diode.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/rs/zerolog/diode/internal/diodes"
+	"github.com/arl/zerolog/diode/internal/diodes"
 )
 
 var bufPool = &sync.Pool{

--- a/diode/diode_example_test.go
+++ b/diode/diode_example_test.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/diode"
+	"github.com/arl/zerolog"
+	"github.com/arl/zerolog/diode"
 )
 
 func ExampleNewWriter() {

--- a/diode/diode_test.go
+++ b/diode/diode_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/diode"
-	"github.com/rs/zerolog/internal/cbor"
+	"github.com/arl/zerolog"
+	"github.com/arl/zerolog/diode"
+	"github.com/arl/zerolog/internal/cbor"
 )
 
 func TestNewWriter(t *testing.T) {

--- a/diode/internal/diodes/many_to_one.go
+++ b/diode/internal/diodes/many_to_one.go
@@ -9,8 +9,8 @@ import (
 // ManyToOne diode is optimal for many writers (go-routines B-n) and a single
 // reader (go-routine A). It is not thread safe for multiple readers.
 type ManyToOne struct {
-	buffer     []unsafe.Pointer
 	writeIndex uint64
+	buffer     []unsafe.Pointer
 	readIndex  uint64
 	alerter    Alerter
 }

--- a/encoder_cbor.go
+++ b/encoder_cbor.go
@@ -5,7 +5,7 @@ package zerolog
 // This file contains bindings to do binary encoding.
 
 import (
-	"github.com/rs/zerolog/internal/cbor"
+	"github.com/arl/zerolog/internal/cbor"
 )
 
 var (

--- a/encoder_json.go
+++ b/encoder_json.go
@@ -6,7 +6,7 @@ package zerolog
 // JSON encoded byte stream.
 
 import (
-	"github.com/rs/zerolog/internal/json"
+	"github.com/arl/zerolog/internal/json"
 )
 
 var (

--- a/event.go
+++ b/event.go
@@ -83,6 +83,26 @@ func (e *Event) Discard() *Event {
 	return nil
 }
 
+// Category assigns a category to the *Event.
+//
+// If the log level associated to this category allows this event to be logged, a
+// 'category' key will be added with the category name as value; however if the log
+// level doesn't allow this event to be logged, Category will return a nil *Event.
+func (e *Event) Category(cat Category) *Event {
+	if e == nil {
+		return e
+	}
+
+	ok, catname := shouldCategory(cat, e.level)
+	if !ok {
+		e = nil
+		return nil
+	}
+	// category enabled for current event, adds it.
+	e.buf = enc.AppendString(enc.AppendKey(e.buf, CategoryFieldName), catname)
+	return e
+}
+
 // Msg sends the *Event with msg added as the message field if not empty.
 //
 // NOTICE: once this method is called, the *Event should be disposed.

--- a/globals.go
+++ b/globals.go
@@ -1,7 +1,10 @@
 package zerolog
 
-import "time"
-import "sync/atomic"
+import (
+	"math"
+	"sync/atomic"
+	"time"
+)
 
 var (
 	// TimestampFieldName is the field name used for the timestamp field.
@@ -15,6 +18,9 @@ var (
 
 	// ErrorFieldName is the field name used for error fields.
 	ErrorFieldName = "error"
+
+	// CategoryFieldName is the field name used for category fields.
+	CategoryFieldName = "category"
 
 	// CallerFieldName is the field name used for caller field.
 	CallerFieldName = "caller"
@@ -48,8 +54,16 @@ var (
 // values is raised, all Loggers will use at least this value.
 //
 // To globally disable logs, set GlobalLevel to Disabled.
+// Note: also set the category-based level, for all log categories.
 func SetGlobalLevel(l Level) {
 	atomic.StoreUint32(gLevel, uint32(l))
+
+	// set all categories at once.
+	catmx.Lock()
+	for i := 0; i < math.MaxUint8; i++ {
+		categories[i].lvl = l
+	}
+	catmx.Unlock()
 }
 
 // GlobalLevel returns the current global log level

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,1 @@
-module github.com/rs/zerolog
+module github.com/arl/zerolog

--- a/hlog/hlog.go
+++ b/hlog/hlog.go
@@ -7,9 +7,9 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/arl/zerolog"
+	"github.com/arl/zerolog/log"
 	"github.com/rs/xid"
-	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 	"github.com/zenazn/goji/web/mutil"
 )
 

--- a/hlog/hlog_example_test.go
+++ b/hlog/hlog_example_test.go
@@ -9,8 +9,8 @@ import (
 
 	"net/http/httptest"
 
-	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/hlog"
+	"github.com/arl/zerolog"
+	"github.com/arl/zerolog/hlog"
 )
 
 // fake alice to avoid dep

--- a/hlog/hlog_test.go
+++ b/hlog/hlog_test.go
@@ -14,8 +14,8 @@ import (
 
 	"net/http/httptest"
 
-	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/internal/cbor"
+	"github.com/arl/zerolog"
+	"github.com/arl/zerolog/internal/cbor"
 )
 
 func decodeIfBinary(out *bytes.Buffer) string {

--- a/internal/cbor/examples/genLog.go
+++ b/internal/cbor/examples/genLog.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/rs/zerolog"
+	"github.com/arl/zerolog"
 )
 
 func writeLog(fname string, count int, useCompress bool) {

--- a/journald/journald.go
+++ b/journald/journald.go
@@ -20,11 +20,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/coreos/go-systemd/journal"
-	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/internal/cbor"
 	"io"
 	"strings"
+
+	"github.com/arl/zerolog"
+	"github.com/arl/zerolog/internal/cbor"
+	"github.com/coreos/go-systemd/journal"
 )
 
 const defaultJournalDPrio = journal.PriNotice

--- a/journald/journald_test.go
+++ b/journald/journald_test.go
@@ -2,8 +2,8 @@
 
 package journald_test
 
-import "github.com/rs/zerolog"
-import "github.com/rs/zerolog/journald"
+import "github.com/arl/zerolog"
+import "github.com/arl/zerolog/journald"
 
 func ExampleNewJournalDWriter() {
 	log := zerolog.New(journald.NewJournalDWriter())

--- a/log.go
+++ b/log.go
@@ -2,12 +2,12 @@
 //
 // A global Logger can be use for simple logging:
 //
-//     import "github.com/rs/zerolog/log"
+//     import "github.com/arl/zerolog/log"
 //
 //     log.Info().Msg("hello world")
 //     // Output: {"time":1494567715,"level":"info","message":"hello world"}
 //
-// NOTE: To import the global logger, import the "log" subpackage "github.com/rs/zerolog/log".
+// NOTE: To import the global logger, import the "log" subpackage "github.com/arl/zerolog/log".
 //
 // Fields can be added to log messages:
 //

--- a/log/log.go
+++ b/log/log.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/rs/zerolog"
+	"github.com/arl/zerolog"
 )
 
 // Logger is the global logger.

--- a/log/log_example_test.go
+++ b/log/log_example_test.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
+	"github.com/arl/zerolog"
+	"github.com/arl/zerolog/log"
 )
 
 // setup would normally be an init() function, however, there seems

--- a/log_example_test.go
+++ b/log_example_test.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/rs/zerolog"
+	"github.com/arl/zerolog"
 )
 
 func ExampleNew() {


### PR DESCRIPTION
Add the concept of category to Event's

Introduce a new type Category (uint8) and a new `Category` method to
Event. If Event.Category is not called, the added feature has no cost
for the end-user.

However if `Event.Category` is called and if the log level assigned to
this category allows the event to be logged, this event will be logged
with an extra key `category` (configurable via CategoryFieldName),
with as value, the category name, if prealably set by client code.

Add, in `category.go` some functions to manage the category-based log
levels and category names.

SetGlobalLevel impacts category levels

There are a maximum of MaxUint8 categories and
a `Category` is a uint8...

globals: use CategoryFieldName as key to log categories
